### PR TITLE
Allow the min/max lifetimes to be specified in the cloud-init

### DIFF
--- a/get-app.sh
+++ b/get-app.sh
@@ -5,6 +5,6 @@ ulimit -n 20000
 sleep 5
 
 chmod +x /opt/server
-/opt/server
+/opt/server $1 $2
 
 


### PR DESCRIPTION
Cloud init -> get-app -> server